### PR TITLE
Update notes and attachments id

### DIFF
--- a/src/lib/zothero/zotero.py
+++ b/src/lib/zothero/zotero.py
@@ -58,7 +58,7 @@ SELECT  items.itemID AS id,
     LEFT JOIN deletedItems
         ON items.itemID = deletedItems.itemID
 -- Ignore notes and attachments
-WHERE items.itemTypeID not IN (1, 14)
+WHERE items.itemTypeID not IN (2, 26)
 AND deletedItems.dateDeleted IS NULL
 """
 


### PR DESCRIPTION
Fix: #29 

Zotero has [added a bunch of new items](https://www.zotero.org/support/kb/item_types_and_fields?do=revisions) therefore the item id has been changed. Here is the new items id list from the database:

![image](https://user-images.githubusercontent.com/3107872/102296519-1c7fd400-3f13-11eb-8657-5aef07521dba.png)

